### PR TITLE
Fix example for mapStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,8 +438,7 @@ func mapStream(
     for elem := range in {
         elem := elem
         s.Go(func() {
-            res := f(elem)
-            return func() { out <- res }
+            out <- f(elem)
         })
     }
     s.Wait()


### PR DESCRIPTION
- no return type expected (supposedly wanted defer?)
- remove temp var and shorten example