### PR TITLE
Fix/deadlock: literal copies lock value

### DIFF
--- a/pool/context_pool.go
+++ b/pool/context_pool.go
@@ -11,7 +11,7 @@ import (
 //
 // A new ContextPool should be created with `New().WithContext(ctx)`.
 type ContextPool struct {
-	errorPool ErrorPool
+	errorPool *ErrorPool
 
 	ctx    context.Context
 	cancel context.CancelFunc

--- a/pool/context_pool.go
+++ b/pool/context_pool.go
@@ -20,16 +20,16 @@ type ContextPool struct {
 // Go submits a task. If it returns an error, the error will be
 // collected and returned by Wait() and the context passed to other
 // tasks will be canceled.
-func (g *ContextPool) Go(f func(ctx context.Context) error) {
-	g.errorPool.Go(func() error {
-		err := f(g.ctx)
+func (p *ContextPool) Go(f func(ctx context.Context) error) {
+	p.errorPool.Go(func() error {
+		err := f(p.ctx)
 		if err != nil {
 			// Leaky abstraction warning: We add the error directly because
 			// otherwise, canceling could cause another goroutine to exit and
 			// return an error before this error was added, which breaks the
 			// expectations of WithFirstError().
-			g.errorPool.addErr(err)
-			g.cancel()
+			p.errorPool.addErr(err)
+			p.cancel()
 			return nil
 		}
 		return err

--- a/pool/error_pool.go
+++ b/pool/error_pool.go
@@ -12,7 +12,7 @@ import (
 //
 // A new ErrorPool should be created using `New().WithErrors()`.
 type ErrorPool struct {
-	pool Pool
+	pool *Pool
 
 	onlyFirstError bool
 
@@ -39,7 +39,7 @@ func (p *ErrorPool) Wait() error {
 func (p *ErrorPool) WithContext(ctx context.Context) *ContextPool {
 	ctx, cancel := context.WithCancel(ctx)
 	return &ContextPool{
-		errorPool: *p,
+		errorPool: p,
 		ctx:       ctx,
 		cancel:    cancel,
 	}

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -93,7 +93,7 @@ func (p *Pool) init() {
 // return errors.
 func (p *Pool) WithErrors() *ErrorPool {
 	return &ErrorPool{
-		pool: *p,
+		pool: p,
 	}
 }
 
@@ -102,7 +102,7 @@ func (p *Pool) WithErrors() *ErrorPool {
 func (p *Pool) WithContext(ctx context.Context) *ContextPool {
 	ctx, cancel := context.WithCancel(ctx)
 	return &ContextPool{
-		errorPool: *p.WithErrors(),
+		errorPool: p.WithErrors(),
 		ctx:       ctx,
 		cancel:    cancel,
 	}


### PR DESCRIPTION
Test with `vet` command, an error occurred. Changing the structure value to a pointer value will fix this potential problem.

``` shell
$ go vet ./...
# github.com/sourcegraph/conc/pool
pool/pool.go:105:14: cannot use *p.WithErrors() (variable of type ErrorPool) as type *ErrorPool in struct literal
# github.com/sourcegraph/conc/pool
vet: pool/pool.go:105:14: cannot use *p.WithErrors() (variable of type ErrorPool) as *ErrorPool value in struct literal
```
