### PR TITLE
doc: add copy-pastable 'go get' to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@
 [![codecov](https://codecov.io/gh/sourcegraph/conc/branch/main/graph/badge.svg?token=MQZTEA1QWT)](https://codecov.io/gh/sourcegraph/conc)
 [![Discord](https://img.shields.io/badge/discord-chat-%235765F2)](https://discord.gg/bvXQXmtRjN)
 
-
 `conc` is your toolbelt for structured concurrency in go, making common tasks
 easier and safer.
 
+```sh
+go get github.com/sourcegraph/conc
+```
 
 # At a glance
 


### PR DESCRIPTION
@michaellzc found it suboptimal that an easily copy-pastable `go get` wasn't available 🙃