### PR TITLE
pool: fix loop variables in tests

### DIFF
--- a/pool/context_pool_test.go
+++ b/pool/context_pool_test.go
@@ -118,6 +118,8 @@ func TestContextPool(t *testing.T) {
 		t.Parallel()
 		for _, maxConcurrent := range []int{1, 10, 100} {
 			t.Run(strconv.Itoa(maxConcurrent), func(t *testing.T) {
+				maxConcurrent := maxConcurrent // copy
+
 				t.Parallel()
 				p := New().WithContext(bgctx).WithMaxGoroutines(maxConcurrent)
 

--- a/pool/result_context_pool_test.go
+++ b/pool/result_context_pool_test.go
@@ -107,6 +107,8 @@ func TestResultContextPool(t *testing.T) {
 		t.Parallel()
 		for _, maxConcurrency := range []int{1, 10, 100} {
 			t.Run(strconv.Itoa(maxConcurrency), func(t *testing.T) {
+				maxConcurrency := maxConcurrency // copy
+
 				t.Parallel()
 				ctx := context.Background()
 				g := NewWithResults[int]().WithContext(ctx).WithMaxGoroutines(maxConcurrency)

--- a/pool/result_error_pool_test.go
+++ b/pool/result_error_pool_test.go
@@ -81,6 +81,8 @@ func TestResultErrorGroup(t *testing.T) {
 	t.Run("limit", func(t *testing.T) {
 		for _, maxConcurrency := range []int{1, 10, 100} {
 			t.Run(strconv.Itoa(maxConcurrency), func(t *testing.T) {
+				maxConcurrency := maxConcurrency // copy
+
 				t.Parallel()
 				g := NewWithResults[int]().WithErrors().WithMaxGoroutines(maxConcurrency)
 


### PR DESCRIPTION
This has been a long-standing discussion (https://github.com/golang/go/issues/20733, https://github.com/golang/go/discussions/56010) but today, variables in iterations are per-loop, not per-iteration, so you need to copy these values for them to be used inside `p.Go`.

Add a `t.Log` inside `p.Go` in the corresponding tests to see that previously, we're always comparing against the last value in the iteration, i.e. 100, and after the change the correct value is used:

<table>
<tr>
<th>before - always the last value</th>
<th>after - uses the correct value</th>
</tr>
<tr>
<td>

```
=== CONT  TestContextPool/limit/100
    context_pool_test.go:128: 100
=== CONT  TestContextPool/limit/10
    context_pool_test.go:128: 100
=== CONT  TestContextPool/limit/100
    context_pool_test.go:128: 100
    context_pool_test.go:128: 100
    context_pool_test.go:128: 100
    context_pool_test.go:128: 100
=== CONT  TestContextPool/limit/10
    context_pool_test.go:128: 100
=== CONT  TestContextPool/limit/1
    context_pool_test.go:128: 100
=== CONT  TestContextPool/limit/100
    context_pool_test.go:128: 100
=== CONT  TestContextPool/limit/10
    context_pool_test.go:128: 100
    context_pool_test.go:128: 100
    context_pool_test.go:128: 100
=== CONT  TestContextPool/limit/1
    context_pool_test.go:128: 100
=== CONT  TestContextPool/limit/10
    context_pool_test.go:128: 100
=== CONT  TestContextPool/limit/1
    context_pool_test.go:128: 100
=== CONT  TestContextPool/limit/10
    context_pool_test.go:128: 100
    context_pool_test.go:128: 100
    context_pool_test.go:128: 100
=== CONT  TestContextPool/limit/1
    context_pool_test.go:128: 100
=== CONT  TestContextPool/limit/10
    context_pool_test.go:128: 100
    context_pool_test.go:128: 100
```
</td>
<td>

```
=== CONT  TestContextPool/limit/1
    context_pool_test.go:130: 1
=== CONT  TestContextPool/limit/100
    context_pool_test.go:130: 100
    context_pool_test.go:130: 100
    context_pool_test.go:130: 100
    context_pool_test.go:130: 100
    context_pool_test.go:130: 100
    context_pool_test.go:130: 100
    context_pool_test.go:130: 100
    context_pool_test.go:130: 100
    context_pool_test.go:130: 100
    context_pool_test.go:130: 100
    context_pool_test.go:130: 100
    context_pool_test.go:130: 100
    context_pool_test.go:130: 100
    context_pool_test.go:130: 100
    context_pool_test.go:130: 100
    context_pool_test.go:130: 100
    context_pool_test.go:130: 100
    context_pool_test.go:130: 100
=== CONT  TestContextPool/limit/10
    context_pool_test.go:130: 10
=== CONT  TestContextPool/limit/100
    context_pool_test.go:130: 100
    context_pool_test.go:130: 100
    context_pool_test.go:130: 100
    context_pool_test.go:130: 100
    context_pool_test.go:130: 100
    context_pool_test.go:130: 100
    context_pool_test.go:130: 100
```
</td>
</tr>
</table>