### PR TITLE
Add CancelOnError option to ContextPool

### DIFF
--- a/pool/context_pool.go
+++ b/pool/context_pool.go
@@ -9,10 +9,10 @@ import (
 type ContextPool struct {
 	errorPool ErrorPool
 
-	failFast bool
-
 	ctx    context.Context
 	cancel context.CancelFunc
+
+	failFast bool
 }
 
 // Go submits a task. If it returns an error, the error will be

--- a/pool/context_pool.go
+++ b/pool/context_pool.go
@@ -36,7 +36,6 @@ func (p *ContextPool) Go(f func(ctx context.Context) error) {
 // Wait cleans up all spawned goroutines, propagates any panics, and
 // returns an error if any of the tasks errored.
 func (p *ContextPool) Wait() error {
-	defer p.cancel()
 	return p.errorPool.Wait()
 }
 
@@ -51,7 +50,7 @@ func (p *ContextPool) WithFirstError() *ContextPool {
 
 // WithFailFast configures the pool to cancel its context as soon as
 // any task returns an error. By default, the pool's context is not
-// canceled until Wait() completes or the parent context is canceled.
+// canceled until the parent context is canceled.
 func (p *ContextPool) WithFailFast() *ContextPool {
 	p.failFast = true
 	return p

--- a/pool/context_pool.go
+++ b/pool/context_pool.go
@@ -48,10 +48,10 @@ func (p *ContextPool) WithFirstError() *ContextPool {
 	return p
 }
 
-// WithFailFast configures the pool to cancel its context as soon as
+// WithCancelOnError configures the pool to cancel its context as soon as
 // any task returns an error. By default, the pool's context is not
 // canceled until the parent context is canceled.
-func (p *ContextPool) WithFailFast() *ContextPool {
+func (p *ContextPool) WithCancelOnError() *ContextPool {
 	p.failFast = true
 	return p
 }

--- a/pool/context_pool_test.go
+++ b/pool/context_pool_test.go
@@ -13,11 +13,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func ExampleContextPool_WithFailFast() {
+func ExampleContextPool_WithCancelOnError() {
 	p := New().
 		WithMaxGoroutines(4).
 		WithContext(context.Background()).
-		WithFailFast()
+		WithCancelOnError()
 	for i := 0; i < 3; i++ {
 		i := i
 		p.Go(func(ctx context.Context) error {
@@ -89,8 +89,8 @@ func TestContextPool(t *testing.T) {
 		})
 	})
 
-	t.Run("WithFailFast", func(t *testing.T) {
-		p := New().WithContext(bgctx).WithFailFast()
+	t.Run("WithCancelOnError", func(t *testing.T) {
+		p := New().WithContext(bgctx).WithCancelOnError()
 		p.Go(func(ctx context.Context) error {
 			<-ctx.Done()
 			return ctx.Err()
@@ -103,7 +103,7 @@ func TestContextPool(t *testing.T) {
 		require.ErrorIs(t, err, err1)
 	})
 
-	t.Run("no WithFailFast", func(t *testing.T) {
+	t.Run("no WithCancelOnError", func(t *testing.T) {
 		p := New().WithContext(bgctx)
 		p.Go(func(ctx context.Context) error {
 			select {
@@ -145,9 +145,9 @@ func TestContextPool(t *testing.T) {
 		require.NotErrorIs(t, err, err2)
 	})
 
-	t.Run("WithFirstError and WithFailFast", func(t *testing.T) {
+	t.Run("WithFirstError and WithCancelOnError", func(t *testing.T) {
 		t.Parallel()
-		p := New().WithContext(bgctx).WithFirstError().WithFailFast()
+		p := New().WithContext(bgctx).WithFirstError().WithCancelOnError()
 		p.Go(func(ctx context.Context) error {
 			return err1
 		})

--- a/pool/result_context_pool.go
+++ b/pool/result_context_pool.go
@@ -47,6 +47,14 @@ func (p *ResultContextPool[T]) WithFirstError() *ResultContextPool[T] {
 	return p
 }
 
+// WithFailFast configures the pool to cancel its context as soon as
+// any task returns an error. By default, the pool's context is not
+// canceled until Wait() completes or the parent context is canceled.
+func (p *ResultContextPool[T]) WithFailFast() *ResultContextPool[T] {
+	p.contextPool.WithFailFast()
+	return p
+}
+
 // WithMaxGoroutines limits the number of goroutines in a pool.
 // Defaults to unlimited. Panics if n < 1.
 func (p *ResultContextPool[T]) WithMaxGoroutines(n int) *ResultContextPool[T] {

--- a/pool/result_context_pool.go
+++ b/pool/result_context_pool.go
@@ -49,7 +49,7 @@ func (p *ResultContextPool[T]) WithFirstError() *ResultContextPool[T] {
 
 // WithFailFast configures the pool to cancel its context as soon as
 // any task returns an error. By default, the pool's context is not
-// canceled until Wait() completes or the parent context is canceled.
+// canceled until the parent context is canceled.
 func (p *ResultContextPool[T]) WithFailFast() *ResultContextPool[T] {
 	p.contextPool.WithFailFast()
 	return p

--- a/pool/result_context_pool.go
+++ b/pool/result_context_pool.go
@@ -47,11 +47,11 @@ func (p *ResultContextPool[T]) WithFirstError() *ResultContextPool[T] {
 	return p
 }
 
-// WithFailFast configures the pool to cancel its context as soon as
+// WithCancelOnError configures the pool to cancel its context as soon as
 // any task returns an error. By default, the pool's context is not
 // canceled until the parent context is canceled.
-func (p *ResultContextPool[T]) WithFailFast() *ResultContextPool[T] {
-	p.contextPool.WithFailFast()
+func (p *ResultContextPool[T]) WithCancelOnError() *ResultContextPool[T] {
+	p.contextPool.WithCancelOnError()
 	return p
 }
 

--- a/pool/result_context_pool_test.go
+++ b/pool/result_context_pool_test.go
@@ -109,18 +109,27 @@ func TestResultContextPool(t *testing.T) {
 
 	t.Run("WithFirstError", func(t *testing.T) {
 		t.Parallel()
-		g := NewWithResults[int]().WithContext(context.Background()).WithFirstError().WithFailFast()
+		g := NewWithResults[int]().WithContext(context.Background()).WithFirstError()
+		sync := make(chan struct{})
 		g.Go(func(ctx context.Context) (int, error) {
-			<-ctx.Done()
-			return 0, err2
+			defer close(sync)
+			return 0, err1
 		})
 		g.Go(func(ctx context.Context) (int, error) {
-			return 0, err1
+			// This test has a race condition. After the first goroutine
+			// completes, this goroutine is woken up because sync is closed.
+			// However, this goroutine might be woken up before the error from
+			// the first goroutine is registered. To prevent that, we sleep for
+			// another 10 milliseconds, giving the other goroutine time to return
+			// and register its error before this goroutine returns its error.
+			<-sync
+			time.Sleep(10 * time.Millisecond)
+			return 0, err2
 		})
 		res, err := g.Wait()
 		require.Len(t, res, 0)
 		require.ErrorIs(t, err, err1)
-		require.NotErrorIs(t, err, context.Canceled)
+		require.NotErrorIs(t, err, err2)
 	})
 
 	t.Run("limit", func(t *testing.T) {

--- a/pool/result_context_pool_test.go
+++ b/pool/result_context_pool_test.go
@@ -63,9 +63,9 @@ func TestResultContextPool(t *testing.T) {
 		require.ErrorIs(t, err, context.Canceled)
 	})
 
-	t.Run("WithFailFast", func(t *testing.T) {
+	t.Run("WithCancelOnError", func(t *testing.T) {
 		t.Parallel()
-		g := NewWithResults[int]().WithContext(context.Background()).WithFailFast()
+		g := NewWithResults[int]().WithContext(context.Background()).WithCancelOnError()
 		g.Go(func(ctx context.Context) (int, error) {
 			<-ctx.Done()
 			return 0, ctx.Err()
@@ -79,7 +79,7 @@ func TestResultContextPool(t *testing.T) {
 		require.ErrorIs(t, err, err1)
 	})
 
-	t.Run("no WithFailFast", func(t *testing.T) {
+	t.Run("no WithCancelOnError", func(t *testing.T) {
 		t.Parallel()
 		g := NewWithResults[int]().WithContext(context.Background())
 		g.Go(func(ctx context.Context) (int, error) {


### PR DESCRIPTION
This adds the `WithCancelOnError()` configuration method to `ContextPool` and `ResultContextPool`, and changes the default behavior to not cancel the pool's context on error.

`ContextPool` initially canceled by default because otherwise, it's no different than an `ErrorPool` that captures a context from its environment. However, doing this by default is surprising and should be explicitly opt-in.