### PR TITLE
doc: fix missing resource cleanup in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ func process(values []int) {
     for _, value := range values {
         feeder <- value
     }
-
+    close(feeder)
     wg.Wait()
 }
 ```


### PR DESCRIPTION
The `stdlib` example in demonstrate `iter.ForEach` missed cleanup `channel` afterwards