### PR TITLE
panics: move PanicCatcher to separate package

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ go get github.com/sourcegraph/conc
 - Use [`stream.Stream`](https://pkg.go.dev/github.com/sourcegraph/conc@v0.1.0/stream#Stream) if you want to process an ordered stream of tasks in parallel with serial callbacks
 - Use [`iter.Map`](https://pkg.go.dev/github.com/sourcegraph/conc@v0.1.0/iter#Map) if you want to concurrently map a slice
 - Use [`iter.ForEach`](https://pkg.go.dev/github.com/sourcegraph/conc@v0.1.0/iter#ForEach) if you want to concurrently iterate over a slice
-- Use [`conc.PanicCatcher`](https://pkg.go.dev/github.com/sourcegraph/conc#PanicCatcher) if you want to catch panics in your own goroutines
+- Use [`panics.Catcher`](https://pkg.go.dev/github.com/sourcegraph/conc/panics#Catcher) if you want to catch panics in your own goroutines
 
 All pools are created with
 [`pool.New()`](https://pkg.go.dev/github.com/sourcegraph/conc@v0.1.0/pool#New)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,11 @@ module github.com/sourcegraph/conc
 go 1.19
 
 require (
+	github.com/sourcegraph/sourcegraph/lib v0.0.0-20221216004406-749998a2ac74
+	github.com/stretchr/testify v1.8.1
+)
+
+require (
 	github.com/cockroachdb/errors v1.9.0 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f // indirect
 	github.com/cockroachdb/redact v1.1.3 // indirect
@@ -14,8 +19,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
-	github.com/sourcegraph/sourcegraph/lib v0.0.0-20221216004406-749998a2ac74 // indirect
-	github.com/stretchr/testify v1.8.1 // indirect
 	golang.org/x/sys v0.0.0-20220829200755-d48e67d00261 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,7 @@ github.com/getsentry/sentry-go v0.13.0/go.mod h1:EOsfu5ZdvKPfeHYV6pTVQnsjfp30+XA
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
 github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/3rZdM=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
+github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
@@ -94,6 +95,7 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -181,6 +183,7 @@ github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1ls
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -367,6 +370,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/panic.go
+++ b/panic.go
@@ -1,0 +1,85 @@
+package conc
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"sync/atomic"
+)
+
+// PanicCatcher is used to catch panics. You can execute a function with Try,
+// which will catch any spawned panic. Try can be called any number of times,
+// from any number of goroutines. Once all calls to Try have completed, you can
+// get the value of the first panic (if any) with Recovered(), or you can just
+// propagate the panic (re-panic) with Repanic().
+type PanicCatcher struct {
+	recovered atomic.Pointer[RecoveredPanic]
+}
+
+// Try executes f, catching any panic it might spawn. It is safe
+// to call from multiple goroutines simultaneously.
+func (p *PanicCatcher) Try(f func()) {
+	defer p.tryRecover()
+	f()
+}
+
+func (p *PanicCatcher) tryRecover() {
+	if val := recover(); val != nil {
+		rp := NewRecoveredPanic(1, val)
+		p.recovered.CompareAndSwap(nil, &rp)
+	}
+}
+
+// Repanic panics if any calls to Try caught a panic. It will panic with the
+// value of the first panic caught, wrapped in a RecoveredPanic with caller
+// information.
+func (p *PanicCatcher) Repanic() {
+	if val := p.Recovered(); val != nil {
+		panic(val)
+	}
+}
+
+// Recovered returns the value of the first panic caught by Try, or nil if
+// no calls to Try panicked.
+func (p *PanicCatcher) Recovered() *RecoveredPanic {
+	return p.recovered.Load()
+}
+
+// NewRecoveredPanic creates a RecoveredPanic from a panic value and a
+// collected stacktrace. The skip parameter allows the caller to skip stack
+// frames when collecting the stacktrace. Calling with a skip of 0 means
+// include the call to NewRecoveredPanic in the stacktrace.
+func NewRecoveredPanic(skip int, value any) RecoveredPanic {
+	// 64 frames should be plenty
+	var callers [64]uintptr
+	n := runtime.Callers(skip+1, callers[:])
+	return RecoveredPanic{
+		Value:   value,
+		Callers: callers[:n],
+		Stack:   debug.Stack(),
+	}
+}
+
+// RecoveredPanic is a panic that was caught with recover().
+type RecoveredPanic struct {
+	// The original value of the panic.
+	Value any
+	// The caller list as returned by runtime.Callers when the panic was
+	// recovered. Can be used to produce a more detailed stack information with
+	// runtime.CallersFrames.
+	Callers []uintptr
+	// The formatted stacktrace from the goroutine where the panic was recovered.
+	// Easier to use than Callers.
+	Stack []byte
+}
+
+func (c *RecoveredPanic) Error() string {
+	return fmt.Sprintf("panic: %v\nstacktrace:\n%s\n", c.Value, c.Stack)
+}
+
+func (c *RecoveredPanic) Unwrap() error {
+	if err, ok := c.Value.(error); ok {
+		return err
+	}
+	return nil
+}

--- a/panics/panics.go
+++ b/panics/panics.go
@@ -1,4 +1,4 @@
-package conc
+package panics
 
 import (
 	"fmt"
@@ -7,23 +7,23 @@ import (
 	"sync/atomic"
 )
 
-// PanicCatcher is used to catch panics. You can execute a function with Try,
+// Catcher is used to catch panics. You can execute a function with Try,
 // which will catch any spawned panic. Try can be called any number of times,
 // from any number of goroutines. Once all calls to Try have completed, you can
 // get the value of the first panic (if any) with Value(), or you can just
 // propagate the panic (re-panic) with Repanic().
-type PanicCatcher struct {
+type Catcher struct {
 	recovered atomic.Pointer[RecoveredPanic]
 }
 
 // Try executes f, catching any panic it might spawn. It is safe
 // to call from multiple goroutines simultaneously.
-func (p *PanicCatcher) Try(f func()) {
+func (p *Catcher) Try(f func()) {
 	defer p.tryRecover()
 	f()
 }
 
-func (p *PanicCatcher) tryRecover() {
+func (p *Catcher) tryRecover() {
 	if val := recover(); val != nil {
 		rp := NewRecoveredPanic(1, val)
 		p.recovered.CompareAndSwap(nil, &rp)
@@ -33,7 +33,7 @@ func (p *PanicCatcher) tryRecover() {
 // Repanic panics if any calls to Try caught a panic. It will panic with the
 // value of the first panic caught, wrapped in a RecoveredPanic with caller
 // information.
-func (p *PanicCatcher) Repanic() {
+func (p *Catcher) Repanic() {
 	if val := p.Recovered(); val != nil {
 		panic(val)
 	}
@@ -41,7 +41,7 @@ func (p *PanicCatcher) Repanic() {
 
 // Recovered returns the value of the first panic caught by Try, or nil if
 // no calls to Try panicked.
-func (p *PanicCatcher) Recovered() *RecoveredPanic {
+func (p *Catcher) Recovered() *RecoveredPanic {
 	return p.recovered.Load()
 }
 

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/sourcegraph/conc"
+	"github.com/sourcegraph/conc/panics"
 	"github.com/sourcegraph/conc/pool"
 )
 
@@ -116,7 +117,7 @@ func (s *Stream) init() {
 // callbacker is responsible for calling the returned callbacks in the order
 // they were submitted. There is only a single instance of callbacker running.
 func (s *Stream) callbacker() {
-	var panicCatcher conc.PanicCatcher
+	var panicCatcher panics.Catcher
 	defer panicCatcher.Repanic()
 
 	// For every scheduled task, read that tasks channel from the queue.

--- a/waitgroup.go
+++ b/waitgroup.go
@@ -2,6 +2,8 @@ package conc
 
 import (
 	"sync"
+
+	"github.com/sourcegraph/conc/panics"
 )
 
 // NewWaitGroup creates a new WaitGroup.
@@ -19,7 +21,7 @@ func NewWaitGroup() *WaitGroup {
 // Also like sync.WaitGroup, it must not be copied after first use.
 type WaitGroup struct {
 	wg sync.WaitGroup
-	pc PanicCatcher
+	pc panics.Catcher
 }
 
 // Go spawns a new goroutine in the WaitGroup.


### PR DESCRIPTION
Proposal: move `conc.PanicCatcher` to a subpackage, `conc/panics.Catcher`. We cannot use `panic` as a package name without conflicting with the builtin `panic()`.

IMO it is a bit strange for `PanicCatcher` to be part of the top-level `conc` package, since:

1. Most users of `conc.WaitGroup`, `conc/pool`, etc will never interact directly with panic catcher
2. While `PanicCatcher` can be used multiple times and concurrently, it only ever retains a single panic, so regardless of safety, in a standalone usecase I imagine one might use an instance of `PanicCatcher` for one goroutine at a time to get more granular `RecoveredPanic`s, so it doesn't really fit in with the theme of `conc` and is more of a utility.