### PR TITLE
Add WaitAndRecover method to WaitGroup

### DIFF
--- a/waitgroup.go
+++ b/waitgroup.go
@@ -41,3 +41,12 @@ func (h *WaitGroup) Wait() {
 	// Propagate a panic if we caught one from a child goroutine.
 	h.pc.Repanic()
 }
+
+// WaitSafe will block until all goroutines spawned with Go exit and will
+// return a *panics.RecoveredPanic if one of the child goroutines panics.
+func (h *WaitGroup) WaitSafe() *panics.RecoveredPanic {
+	h.wg.Wait()
+
+	// Return a recovered panic if we caught one from a child goroutine.
+	return h.pc.Recovered()
+}

--- a/waitgroup.go
+++ b/waitgroup.go
@@ -42,9 +42,9 @@ func (h *WaitGroup) Wait() {
 	h.pc.Repanic()
 }
 
-// WaitSafe will block until all goroutines spawned with Go exit and will
-// return a *panics.RecoveredPanic if one of the child goroutines panics.
-func (h *WaitGroup) WaitSafe() *panics.RecoveredPanic {
+// WaitAndRecover will block until all goroutines spawned with Go exit and
+// will return a *panics.RecoveredPanic if one of the child goroutines panics.
+func (h *WaitGroup) WaitAndRecover() *panics.RecoveredPanic {
 	h.wg.Wait()
 
 	// Return a recovered panic if we caught one from a child goroutine.

--- a/waitgroup_test.go
+++ b/waitgroup_test.go
@@ -99,30 +99,30 @@ func TestWaitGroup(t *testing.T) {
 			require.Equal(t, int64(2), i.Load())
 		})
 
-		t.Run("is caught by waitsafe", func(t *testing.T) {
+		t.Run("is caught by waitandrecover", func(t *testing.T) {
 			t.Parallel()
 			var wg WaitGroup
 			wg.Go(func() {
 				panic("super bad thing")
 			})
-			p := wg.WaitSafe()
-			require.Contains(t, p.Error(), "super bad thing", p.Error())
+			p := wg.WaitAndRecover()
+			require.Equal(t, p.Value, "super bad thing")
 		})
 
-		t.Run("one is caught by waitsafe", func(t *testing.T) {
+		t.Run("one is caught by waitandrecover", func(t *testing.T) {
 			t.Parallel()
 			var wg WaitGroup
 			wg.Go(func() {
-				panic("one bad thing")
+				panic("super bad thing")
 			})
 			wg.Go(func() {
-				panic("another bad thing")
+				panic("super badder thing")
 			})
-			p := wg.WaitSafe()
-			require.Contains(t, p.Error(), "bad thing", p.Error())
+			p := wg.WaitAndRecover()
+			require.NotNil(t, p)
 		})
 
-		t.Run("nonpanics run successfully with waitsafe", func(t *testing.T) {
+		t.Run("nonpanics run successfully with waitandrecover", func(t *testing.T) {
 			t.Parallel()
 			var wg WaitGroup
 			var i atomic.Int64
@@ -135,8 +135,8 @@ func TestWaitGroup(t *testing.T) {
 			wg.Go(func() {
 				i.Add(1)
 			})
-			p := wg.WaitSafe()
-			require.Contains(t, p.Error(), "super bad thing", p.Error())
+			p := wg.WaitAndRecover()
+			require.Equal(t, p.Value, "super bad thing")
 			require.Equal(t, int64(2), i.Load())
 		})
 	})

--- a/waitgroup_test.go
+++ b/waitgroup_test.go
@@ -98,5 +98,46 @@ func TestWaitGroup(t *testing.T) {
 			require.Panics(t, wg.Wait)
 			require.Equal(t, int64(2), i.Load())
 		})
+
+		t.Run("is caught by waitsafe", func(t *testing.T) {
+			t.Parallel()
+			var wg WaitGroup
+			wg.Go(func() {
+				panic("super bad thing")
+			})
+			p := wg.WaitSafe()
+			require.Contains(t, p.Error(), "super bad thing", p.Error())
+		})
+
+		t.Run("one is caught by waitsafe", func(t *testing.T) {
+			t.Parallel()
+			var wg WaitGroup
+			wg.Go(func() {
+				panic("one bad thing")
+			})
+			wg.Go(func() {
+				panic("another bad thing")
+			})
+			p := wg.WaitSafe()
+			require.Contains(t, p.Error(), "bad thing", p.Error())
+		})
+
+		t.Run("nonpanics run successfully with waitsafe", func(t *testing.T) {
+			t.Parallel()
+			var wg WaitGroup
+			var i atomic.Int64
+			wg.Go(func() {
+				i.Add(1)
+			})
+			wg.Go(func() {
+				panic("super bad thing")
+			})
+			wg.Go(func() {
+				i.Add(1)
+			})
+			p := wg.WaitSafe()
+			require.Contains(t, p.Error(), "super bad thing", p.Error())
+			require.Equal(t, int64(2), i.Load())
+		})
 	})
 }


### PR DESCRIPTION
Resolves #29.

👋 My attempt at resolving #29. I wasn't sure if was better to reimplement `Wait` in terms of `WaitSafe`. I think leaving the code as it looks a bit cleaner, so I just left it.

I also wondered if it is better to say in the docs that `WaitSafe` will return the first panic it encounters and add a test for that. That is true, right?

Thank you!