### PR TITLE
iter: introduce Iterator with configurable concurrency

### DIFF
--- a/iter/iter.go
+++ b/iter/iter.go
@@ -9,6 +9,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+// defaultConcurrency returns the default maximum concurrency to
+// use within this package.
+func defaultConcurrency() int { return runtime.GOMAXPROCS(0) }
+
 // Iterator can be used to configure the behaviour of ForEach
 // and ForEachIdx. The zero value is safe to use with reasonable
 // defaults.
@@ -55,7 +59,7 @@ func ForEachIdx[T any](input []T, f func(int, *T)) { Iterator[T]{}.ForEachIdx(in
 // index of the element to the callback.
 func (iter Iterator[T]) ForEachIdx(input []T, f func(int, *T)) {
 	if iter.Concurrency == 0 {
-		iter.Concurrency = runtime.GOMAXPROCS(0)
+		iter.Concurrency = defaultConcurrency()
 	}
 
 	numInput := len(input)

--- a/iter/iter.go
+++ b/iter/iter.go
@@ -60,6 +60,7 @@ func ForEachIdx[T any](input []T, f func(int, *T)) { Iterator[T]{}.ForEachIdx(in
 // index of the element to the callback.
 func (iter Iterator[T]) ForEachIdx(input []T, f func(int, *T)) {
 	if iter.MaxGoroutines == 0 {
+		// iter is a value receiver and is hence safe to mutate
 		iter.MaxGoroutines = defaultMaxGoroutines()
 	}
 

--- a/iter/iter_test.go
+++ b/iter/iter_test.go
@@ -5,8 +5,24 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestIterator(t *testing.T) {
+	t.Parallel()
+
+	t.Run("safe for reuse", func(t *testing.T) {
+		t.Parallel()
+
+		iterator := Iterator[int]{Concurrency: 999}
+
+		// iter.Concurrency > numInput case that updates iter.Concurrency
+		iterator.ForEachIdx([]int{1, 2, 3}, func(i int, t *int) {})
+
+		assert.Equal(t, iterator.Concurrency, 999)
+	})
+}
 
 func TestForEachIdx(t *testing.T) {
 	t.Parallel()

--- a/iter/iter_test.go
+++ b/iter/iter_test.go
@@ -17,18 +17,18 @@ func TestIterator(t *testing.T) {
 	t.Run("safe for reuse", func(t *testing.T) {
 		t.Parallel()
 
-		iterator := Iterator[int]{Concurrency: 999}
+		iterator := Iterator[int]{MaxGoroutines: 999}
 
 		// iter.Concurrency > numInput case that updates iter.Concurrency
 		iterator.ForEachIdx([]int{1, 2, 3}, func(i int, t *int) {})
 
-		assert.Equal(t, iterator.Concurrency, 999)
+		assert.Equal(t, iterator.MaxGoroutines, 999)
 	})
 
-	t.Run("allows more than defaultConcurrency() concurrent tasks", func(t *testing.T) {
+	t.Run("allows more than defaultMaxGoroutines() concurrent tasks", func(t *testing.T) {
 		t.Parallel()
 
-		wantConcurrency := 2 * defaultConcurrency()
+		wantConcurrency := 2 * defaultMaxGoroutines()
 
 		testDone, forEachDone := make(chan struct{}), make(chan struct{})
 
@@ -38,7 +38,7 @@ func TestIterator(t *testing.T) {
 			// to return until the conclusion of the test, so ForEach
 			// will block.
 			tasks := make([]int, wantConcurrency)
-			iterator := Iterator[int]{Concurrency: wantConcurrency}
+			iterator := Iterator[int]{MaxGoroutines: wantConcurrency}
 
 			iterator.ForEach(tasks, func(t *int) {
 				concurrentTasks.Add(1)

--- a/iter/iter_test.go
+++ b/iter/iter_test.go
@@ -4,7 +4,6 @@ import (
 	"strconv"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/stretchr/testify/assert"
@@ -45,7 +44,10 @@ func TestIterator(t *testing.T) {
 				// Signal to the rest of the tasks to stop.
 				close(maxConcurrencyHit)
 			} else {
-				// Wait until we hit max concurrency before exiting
+				// Wait until we hit max concurrency before exiting.
+				// This ensures that all tasks have been started
+				// in parallel, despite being a larger input set than
+				// defaultMaxGoroutines().
 				<-maxConcurrencyHit
 			}
 		})


### PR DESCRIPTION
Adds configurable concurrency to `iter` via a new type `Iterator` with ~no overhead and no API changes:

```go
customIterator := iter.Iterator{MaxGoroutines: 42}
customIterator.ForEach(...)

// zero value is safe, defaults to runtime.GOMAXPROCS(0)
iter.Iterator{}.ForEach(...)

// package-level functions behave the same as before
iter.ForEach(...)
```

If the API is agreeable, I can make a follow-up PR to introduce something similar for `Map` and friends. Note that `Map` cannot simply be a method on `Iterator` because methods cannot accept type parameters, and we do not want the return type `R` on `Iterator` where `ForEach` does not use `R`.

Relevant to https://github.com/sourcegraph/conc/issues/36, closes https://github.com/sourcegraph/conc/issues/55

---

Before:

```
go test -run=XXX -bench=. -benchmem ./iter
goos: darwin
goarch: arm64
pkg: github.com/sourcegraph/conc/iter
BenchmarkForEach/0-10   13291378                77.89 ns/op          120 B/op          4 allocs/op
BenchmarkForEach/1-10    2048739               607.5 ns/op           144 B/op          5 allocs/op
BenchmarkForEach/8-10     441230              2843 ns/op             312 B/op         12 allocs/op
BenchmarkForEach/100-10                   278910              4847 ns/op             360 B/op         14 allocs/op
BenchmarkForEach/1000-10                   42801             31772 ns/op             360 B/op         14 allocs/op
BenchmarkForEach/10000-10                   2192            521428 ns/op             397 B/op         14 allocs/op
BenchmarkForEach/100000-10                   187           6115313 ns/op            4653 B/op         14 allocs/op
PASS
ok      github.com/sourcegraph/conc/iter        10.492s
```

After:

```
go test -run=XXX -bench=. -benchmem ./iter
goos: darwin
goarch: arm64
pkg: github.com/sourcegraph/conc/iter
BenchmarkForEach/0-10   13504274                77.28 ns/op          120 B/op          4 allocs/op
BenchmarkForEach/1-10    2133229               560.1 ns/op           144 B/op          5 allocs/op
BenchmarkForEach/8-10     488190              2274 ns/op             312 B/op         12 allocs/op
BenchmarkForEach/100-10                   295342              3770 ns/op             360 B/op         14 allocs/op
BenchmarkForEach/1000-10                   33836             35229 ns/op             360 B/op         14 allocs/op
BenchmarkForEach/10000-10                   2001            618155 ns/op             402 B/op         14 allocs/op
BenchmarkForEach/100000-10                   175           6827000 ns/op            4948 B/op         14 allocs/op
PASS
ok      github.com/sourcegraph/conc/iter        10.241s
```