### PR TITLE
Document that Go() blocks until the task can be started

### DIFF
--- a/pool/context_pool.go
+++ b/pool/context_pool.go
@@ -16,7 +16,8 @@ type ContextPool struct {
 }
 
 // Go submits a task. If it returns an error, the error will be
-// collected and returned by Wait().
+// collected and returned by Wait(). If all goroutines in the pool
+// are busy, a call to Go() will block until the task can be started.
 func (p *ContextPool) Go(f func(ctx context.Context) error) {
 	p.errorPool.Go(func() error {
 		err := f(p.ctx)

--- a/pool/error_pool.go
+++ b/pool/error_pool.go
@@ -20,7 +20,8 @@ type ErrorPool struct {
 	errs error
 }
 
-// Go submits a task to the pool.
+// Go submits a task to the pool. If all goroutines in the pool
+// are busy, a call to Go() will block until the task can be started.
 func (p *ErrorPool) Go(f func() error) {
 	p.pool.Go(func() {
 		p.addErr(f())

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -31,7 +31,8 @@ type Pool struct {
 	initOnce sync.Once
 }
 
-// Go submits a task to be run in the pool.
+// Go submits a task to be run in the pool. If all goroutines in the pool
+// are busy, a call to Go() will block until the task can be started.
 func (p *Pool) Go(f func()) {
 	p.init()
 

--- a/pool/result_context_pool.go
+++ b/pool/result_context_pool.go
@@ -14,7 +14,8 @@ type ResultContextPool[T any] struct {
 	collectErrored bool
 }
 
-// Go submits a task to the pool.
+// Go submits a task to the pool. If all goroutines in the pool
+// are busy, a call to Go() will block until the task can be started.
 func (p *ResultContextPool[T]) Go(f func(context.Context) (T, error)) {
 	p.contextPool.Go(func(ctx context.Context) error {
 		res, err := f(ctx)

--- a/pool/result_error_pool.go
+++ b/pool/result_error_pool.go
@@ -17,7 +17,8 @@ type ResultErrorPool[T any] struct {
 	collectErrored bool
 }
 
-// Go submits a task to the pool.
+// Go submits a task to the pool. If all goroutines in the pool
+// are busy, a call to Go() will block until the task can be started.
 func (p *ResultErrorPool[T]) Go(f func() (T, error)) {
 	p.errorPool.Go(func() error {
 		res, err := f()

--- a/pool/result_pool.go
+++ b/pool/result_pool.go
@@ -24,7 +24,8 @@ type ResultPool[T any] struct {
 	agg  resultAggregator[T]
 }
 
-// Go submits a task to the pool.
+// Go submits a task to the pool. If all goroutines in the pool
+// are busy, a call to Go() will block until the task can be started.
 func (p *ResultPool[T]) Go(f func() T) {
 	p.pool.Go(func() {
 		p.agg.add(f())

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -56,7 +56,9 @@ type Callback func()
 // will be executed concurrently in worker goroutines. Then, the callbacks
 // returned by the tasks will be executed in the order that the tasks were
 // submitted. All callbacks will be executed by the same goroutine, so no
-// synchronization is necessary between callbacks.
+// synchronization is necessary between callbacks. If all goroutines in the
+// stream's pool are busy, a call to Go() will block until the task can be
+// started.
 func (s *Stream) Go(f Task) {
 	s.init()
 


### PR DESCRIPTION
A call to `Go()` will block if all the goroutines in the underlying pool are already handling a task. This documents that behavior. 

Fixes #61