### PR TITLE
iter: introduce Mapper type with configurable Iterator

### DIFF
--- a/iter/iter_test.go
+++ b/iter/iter_test.go
@@ -1,6 +1,7 @@
 package iter
 
 import (
+	"fmt"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -8,6 +9,22 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func ExampleIterator() {
+	input := []int{1, 2, 3, 4}
+	iterator := Iterator[int]{
+		MaxGoroutines: len(input) / 2,
+	}
+
+	iterator.ForEach(input, func(v *int) {
+		if *v%2 == 0 {
+			fmt.Println(*v)
+		}
+	})
+	// Output:
+	// 2
+	// 4
+}
 
 func TestIterator(t *testing.T) {
 	t.Parallel()

--- a/iter/map.go
+++ b/iter/map.go
@@ -6,34 +6,27 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// Mapper can be used to configure the behaviour of iterators that
-// have a result type R, such as Map and MapErr. The zero value is
-// safe to use with reasonable defaults.
+// Mapper is an Iterator with a result type R. It can be used to configure
+// the behaviour of Map and MapErr. The zero value is safe to use with
+// reasonable defaults.
 //
 // Mapper is also safe for reuse and concurrent use.
-type Mapper[T, R any] struct {
-	// Iterator is the underlying implementation of Mapper methods.
-	// It can be used to configure the maximum number of goroutines
-	// that Mapper methods can use.
-	Iterator[T]
-}
+type Mapper[T, R any] Iterator[T]
 
 // Map applies f to each element of input, returning the mapped result.
 //
-// Map uses Iterator to perform the iteration, which always uses at most
-// runtime.GOMAXPROCS goroutines. For a configurable goroutine limit,
-// use a custom Mapper.
+// Map always uses at most runtime.GOMAXPROCS goroutines. For a configurable
+// goroutine limit, use a custom Mapper.
 func Map[T, R any](input []T, f func(*T) R) []R {
 	return Mapper[T, R]{}.Map(input, f)
 }
 
 // Map applies f to each element of input, returning the mapped result.
 //
-// Map uses Iterator to perform the iteration, using up to the configured
-// Iterator's maximum number of goroutines.
+// Map uses up to the configured Mapper's maximum number of goroutines.
 func (m Mapper[T, R]) Map(input []T, f func(*T) R) []R {
 	res := make([]R, len(input))
-	m.Iterator.ForEachIdx(input, func(i int, t *T) {
+	Iterator[T](m).ForEachIdx(input, func(i int, t *T) {
 		res[i] = f(t)
 	})
 	return res
@@ -42,9 +35,8 @@ func (m Mapper[T, R]) Map(input []T, f func(*T) R) []R {
 // MapErr applies f to each element of the input, returning the mapped result
 // and a combined error of all returned errors.
 //
-// MapErr uses Iterator to perform the iteration, which always uses at
-// most runtime.GOMAXPROCS goroutines. For a configurable goroutine limit,
-// use a custom Mapper.
+// Map always uses at most runtime.GOMAXPROCS goroutines. For a configurable
+// goroutine limit, use a custom Mapper.
 func MapErr[T, R any](input []T, f func(*T) (R, error)) ([]R, error) {
 	return Mapper[T, R]{}.MapErr(input, f)
 }
@@ -52,15 +44,14 @@ func MapErr[T, R any](input []T, f func(*T) (R, error)) ([]R, error) {
 // MapErr applies f to each element of the input, returning the mapped result
 // and a combined error of all returned errors.
 //
-// MapErr uses Iterator to perform the iteration, using up to the configured
-// Iterator's maximum number of goroutines.
+// Map uses up to the configured Mapper's maximum number of goroutines.
 func (m Mapper[T, R]) MapErr(input []T, f func(*T) (R, error)) ([]R, error) {
 	var (
 		res    = make([]R, len(input))
 		errMux sync.Mutex
 		errs   error
 	)
-	m.Iterator.ForEachIdx(input, func(i int, t *T) {
+	Iterator[T](m).ForEachIdx(input, func(i int, t *T) {
 		var err error
 		res[i], err = f(t)
 		if err != nil {

--- a/iter/map.go
+++ b/iter/map.go
@@ -6,10 +6,34 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+// Mapper can be used to configure the behaviour of iterators that
+// have a result type R, such as Map and MapErr. The zero value is
+// safe to use with reasonable defaults.
+//
+// Mapper is also safe for reuse and concurrent use.
+type Mapper[T, R any] struct {
+	// Iterator is the underlying implementation of Mapper methods.
+	// It can be used to configure the maximum number of goroutines
+	// that Mapper methods can use.
+	Iterator[T]
+}
+
 // Map applies f to each element of input, returning the mapped result.
+//
+// Map uses Iterator to perform the iteration, which always uses at most
+// runtime.GOMAXPROCS goroutines. For a configurable goroutine limit,
+// use a custom Mapper.
 func Map[T, R any](input []T, f func(*T) R) []R {
+	return Mapper[T, R]{}.Map(input, f)
+}
+
+// Map applies f to each element of input, returning the mapped result.
+//
+// Map uses Iterator to perform the iteration, using up to the configured
+// Iterator's maximum number of goroutines.
+func (m Mapper[T, R]) Map(input []T, f func(*T) R) []R {
 	res := make([]R, len(input))
-	ForEachIdx(input, func(i int, t *T) {
+	m.Iterator.ForEachIdx(input, func(i int, t *T) {
 		res[i] = f(t)
 	})
 	return res
@@ -17,13 +41,26 @@ func Map[T, R any](input []T, f func(*T) R) []R {
 
 // MapErr applies f to each element of the input, returning the mapped result
 // and a combined error of all returned errors.
+//
+// MapErr uses Iterator to perform the iteration, which always uses at
+// most runtime.GOMAXPROCS goroutines. For a configurable goroutine limit,
+// use a custom Mapper.
 func MapErr[T, R any](input []T, f func(*T) (R, error)) ([]R, error) {
+	return Mapper[T, R]{}.MapErr(input, f)
+}
+
+// MapErr applies f to each element of the input, returning the mapped result
+// and a combined error of all returned errors.
+//
+// MapErr uses Iterator to perform the iteration, using up to the configured
+// Iterator's maximum number of goroutines.
+func (m Mapper[T, R]) MapErr(input []T, f func(*T) (R, error)) ([]R, error) {
 	var (
 		res    = make([]R, len(input))
 		errMux sync.Mutex
 		errs   error
 	)
-	ForEachIdx(input, func(i int, t *T) {
+	m.Iterator.ForEachIdx(input, func(i int, t *T) {
 		var err error
 		res[i], err = f(t)
 		if err != nil {

--- a/iter/map_test.go
+++ b/iter/map_test.go
@@ -2,10 +2,23 @@ package iter
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func ExampleMapper() {
+	input := []int{1, 2, 3, 4}
+	mapper := Mapper[int, bool]{
+		MaxGoroutines: len(input) / 2,
+	}
+
+	results := mapper.Map(input, func(v *int) bool { return *v%2 == 0 })
+	fmt.Println(results)
+	// Output:
+	// [false true false true]
+}
 
 func TestMap(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
This follows up https://github.com/sourcegraph/conc/pull/63 by introducing a `Mapper` type that can be used to configure mapping behaviour, while keeping the top-level `Map` and `MapErr` functions.

Relevant to https://github.com/sourcegraph/conc/issues/55
Stacked on https://github.com/sourcegraph/conc/pull/67

<details>
  <summary>Previous discussion points</summary>

All superseded by https://github.com/sourcegraph/conc/pull/68#issuecomment-1384393956

## `type Mapper struct` vs `type Mapper = Iterator`

the `Mapper` type must be a struct - IMO this type only really needs to be an `Iterator` with a result type `R`, defined as a type alias:

```go
type Mapper[T, R any] = Iterator[T]
```

This would reinforce that `Mapper` is simply an `Iterator` that also works with result types, and shouldn't have additional behaviours/state that might be better suited to a `Pool` type.

Sadly, this isn't possible in Go 1.19 - type aliases currently cannot have type parameters of their own. However, **a proposal to change this is accepted** (https://github.com/golang/go/issues/46477), so we may want to wait for it since it's [tagged as part of Go 1.20](https://github.com/golang/go/issues/46477#issuecomment-1134888278), but there hasn't been much activity on it and with the Go 1.20 coming up soon it might not have made it into the release.

## `Mapper.ForEach`

Another consideration: with both the above approaches, `Mapper` instances have `ForEach`, etc from `Iterator` accessible as well, which makes for a larger visible API surface. I think it's harmless, but if we want to hide it, we may want to use `type Mapper struct` and either:

- Make `(Mapper).Iterator` a named rather than embedded field
- Make `Mapper` a copy-pasta of `Iterator`, and create new `Iterator` instances that use `(Mapper).MaxGoroutines` - this is a bit tedious and IMO potentially confusing


</details>
