### PR TITLE
panics: add single-fn Try at package level

### DIFF
--- a/panics/try.go
+++ b/panics/try.go
@@ -1,0 +1,11 @@
+package panics
+
+// Try executes f, catching and returning any panic it might spawn.
+//
+// The recovered panic can be propagated with panic(), or handled as a normal error with
+// (*RecoveredPanic).AsError().
+func Try(f func()) *RecoveredPanic {
+	var c Catcher
+	c.Try(f)
+	return c.Recovered()
+}

--- a/panics/try_test.go
+++ b/panics/try_test.go
@@ -1,0 +1,33 @@
+package panics
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("panics", func(t *testing.T) {
+		t.Parallel()
+
+		err := errors.New("SOS")
+		recovered := Try(func() { panic(err) })
+		require.ErrorIs(t, recovered.AsError(), err)
+		require.ErrorAs(t, recovered.AsError(), &err)
+		// The exact contents aren't tested because the stacktrace contains local file paths
+		// and even the structure of the stacktrace is bound to be unstable over time. Just
+		// test a couple of basics.
+		require.Contains(t, recovered.String(), "SOS", "formatted panic should contain the panic message")
+		require.Contains(t, recovered.String(), "panics.(*Catcher).Try", recovered.String(), "formatted panic should contain the stack trace")
+	})
+
+	t.Run("no panic", func(t *testing.T) {
+		t.Parallel()
+
+		recovered := Try(func() {})
+		require.Nil(t, recovered)
+	})
+}


### PR DESCRIPTION
`panics` is pretty useful for cases where you're dealing with a third-party library that panics instead of handling errors, which is sadly a non-zero number of libraries. For one-off usages, however, using `Catcher` is clunky because it's designed to be reused - this adds a convenience function `Try` that attempts a single function and recovers from panics it raises.