### PR TITLE
Add WaitAndRecover Example

### DIFF
--- a/waitgroup_test.go
+++ b/waitgroup_test.go
@@ -24,6 +24,21 @@ func ExampleWaitGroup() {
 	// 10
 }
 
+func ExampleWaitGroupAndRecover() {
+
+	var wg WaitGroup
+
+	wg.Go(func() {
+		panic("super bad thing")
+	})
+
+	wg.WaitAndRecover()
+
+	fmt.Println(wg.WaitAndRecover().Value)
+	// Output:
+	// super bad thing
+}
+
 func TestWaitGroup(t *testing.T) {
 	t.Parallel()
 
@@ -70,7 +85,7 @@ func TestWaitGroup(t *testing.T) {
 			require.Panics(t, wg.Wait)
 		})
 
-		t.Run("nonpanics do not overwrite panic", func(t *testing.T) {
+		t.Run("non-panics do not overwrite panic", func(t *testing.T) {
 			t.Parallel()
 			var wg WaitGroup
 			wg.Go(func() {
@@ -82,7 +97,7 @@ func TestWaitGroup(t *testing.T) {
 			require.Panics(t, wg.Wait)
 		})
 
-		t.Run("nonpanics run successfully", func(t *testing.T) {
+		t.Run("non-panics run successfully", func(t *testing.T) {
 			t.Parallel()
 			var wg WaitGroup
 			var i atomic.Int64


### PR DESCRIPTION
I add `WaitAndRecover` func example in unit test, hope you like it

```golang

func ExampleWaitGroupAndRecover() {

	var wg WaitGroup

	wg.Go(func() {
		panic("super bad thing")
	})

	wg.WaitAndRecover()

	fmt.Println(wg.WaitAndRecover().Value)
	// Output:
	// super bad thing
}

```