### PR TITLE
fix readme example: iter.Map arg err

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ func concMap(
 ```go
 func concMap(
     input []int,
-    f func(int) int,
+    f func(*int) int,
 ) []int {
     return iter.Map(input, f)
 }


### PR DESCRIPTION
example for iter.Map, function handler args is a pointer