### PR TITLE
pool: ensure ContextPool.cancel() is called

### DIFF
--- a/pool/context_pool.go
+++ b/pool/context_pool.go
@@ -40,6 +40,8 @@ func (p *ContextPool) Go(f func(ctx context.Context) error) {
 // Wait cleans up all spawned goroutines, propagates any panics, and
 // returns an error if any of the tasks errored.
 func (p *ContextPool) Wait() error {
+	// Make sure we call cancel after pool is done to avoid memory leakage.
+	defer p.cancel()
 	return p.errorPool.Wait()
 }
 


### PR DESCRIPTION
Now that we [no longer cancel-on-error by default](#23), it's possible that a `ContextPool` can be consumed without ever cancelling its context, which causes a goroutine leakage - this change ensures that we call `p.cancel()` (which can safely be called multiple times) on `p.Wait()`.

Alternatively, we could also only configure a cancellable context when the user calls `p.WithCancelOnError()`, but the discussion over at https://github.com/sourcegraph/conc/issues/86#issuecomment-1422595564 indicates that there is a strong desire for the ability to cancel a `ContextPool` without providing an additional context, so I decided not to go this route for now.

No additional tests because there should be no behaviour changes/additions.