### PR TITLE
pool: let WithCancelOnError also cancel on panics

### DIFF
--- a/pool/result_context_pool_test.go
+++ b/pool/result_context_pool_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -98,6 +99,29 @@ func TestResultContextPool(t *testing.T) {
 		require.Len(t, res, 0)
 		require.ErrorIs(t, err, context.Canceled)
 		require.ErrorIs(t, err, err1)
+	})
+
+	t.Run("WithCancelOnError and panic", func(t *testing.T) {
+		t.Parallel()
+		p := NewWithResults[int]().
+			WithContext(context.Background()).
+			WithCancelOnError()
+		var cancelledTasks atomic.Int64
+		p.Go(func(ctx context.Context) (int, error) {
+			<-ctx.Done()
+			cancelledTasks.Add(1)
+			return 0, ctx.Err()
+		})
+		p.Go(func(ctx context.Context) (int, error) {
+			<-ctx.Done()
+			cancelledTasks.Add(1)
+			return 0, ctx.Err()
+		})
+		p.Go(func(ctx context.Context) (int, error) {
+			panic("abort!")
+		})
+		assert.Panics(t, func() { _, _ = p.Wait() })
+		assert.EqualValues(t, 2, cancelledTasks.Load())
 	})
 
 	t.Run("no WithCancelOnError", func(t *testing.T) {


### PR DESCRIPTION
On `(*ContextPool).WithCancelOnError()` task errors, we cancel the context - but what if a task _panics_? I think it might be reasonable to assume that this will trigger a context cancellation since a panic is broadly an "error". This isn't the case in the current implementation, because a panic will abort before `ContextPool`'s error handling - if one task panics, other tasks will continue.

This change proposes that we catch panics separately for the `(*ContextPool).WithCancelOnError()` case, which allows us to cancel the pool's context before propagating the panic.