### PR TITLE
Added successful case for context pool, returns before timeout

### DIFF
--- a/panics/panics_test.go
+++ b/panics/panics_test.go
@@ -156,7 +156,7 @@ func TestRecoveredAsError(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
-	t.Run("as error is not nil nil", func(t *testing.T) {
+	t.Run("as error is not nil", func(t *testing.T) {
 		t.Parallel()
 		fn := func() error {
 			var c Catcher

--- a/pool/context_pool_test.go
+++ b/pool/context_pool_test.go
@@ -116,9 +116,7 @@ func TestContextPool(t *testing.T) {
 
 		t.Run("return before timed out", func(t *testing.T) {
 			t.Parallel()
-			ctx, cancel := context.WithTimeout(bgctx, 2*time.Millisecond)
-			defer cancel()
-			p := New().WithContext(ctx)
+			p := New().WithContext(context.Background())
 			p.Go(func(ctx context.Context) error {
 				select {
 				case <-ctx.Done():

--- a/pool/context_pool_test.go
+++ b/pool/context_pool_test.go
@@ -113,6 +113,22 @@ func TestContextPool(t *testing.T) {
 			})
 			require.ErrorIs(t, p.Wait(), context.DeadlineExceeded)
 		})
+
+		t.Run("return before timed out", func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithTimeout(bgctx, 2*time.Millisecond)
+			defer cancel()
+			p := New().WithContext(ctx)
+			p.Go(func(ctx context.Context) error {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(1 * time.Millisecond):
+					return nil
+				}
+			})
+			require.NoError(t, p.Wait())
+		})
 	})
 
 	t.Run("WithCancelOnError", func(t *testing.T) {


### PR DESCRIPTION
I think we need an example of, if the tasks return before the context cancelled due to timeout, it should success