### PR TITLE
panics: reduce naming stutter in panics.RecoveredPanic

### DIFF
--- a/panics/panics_test.go
+++ b/panics/panics_test.go
@@ -143,7 +143,7 @@ func TestCatcher(t *testing.T) {
 	})
 }
 
-func TestRecoveredPanicAsError(t *testing.T) {
+func TestRecoveredAsError(t *testing.T) {
 	t.Parallel()
 	t.Run("as error is nil", func(t *testing.T) {
 		t.Parallel()

--- a/panics/try.go
+++ b/panics/try.go
@@ -3,8 +3,8 @@ package panics
 // Try executes f, catching and returning any panic it might spawn.
 //
 // The recovered panic can be propagated with panic(), or handled as a normal error with
-// (*RecoveredPanic).AsError().
-func Try(f func()) *RecoveredPanic {
+// (*panics.Recovered).AsError().
+func Try(f func()) *Recovered {
 	var c Catcher
 	c.Try(f)
 	return c.Recovered()

--- a/waitgroup.go
+++ b/waitgroup.go
@@ -43,8 +43,8 @@ func (h *WaitGroup) Wait() {
 }
 
 // WaitAndRecover will block until all goroutines spawned with Go exit and
-// will return a *panics.RecoveredPanic if one of the child goroutines panics.
-func (h *WaitGroup) WaitAndRecover() *panics.RecoveredPanic {
+// will return a *panics.Recovered if one of the child goroutines panics.
+func (h *WaitGroup) WaitAndRecover() *panics.Recovered {
 	h.wg.Wait()
 
 	// Return a recovered panic if we caught one from a child goroutine.


### PR DESCRIPTION
Renames `panics.RecoveredPanic` and friends, which stutters somewhat, to just `panics.Recovered`.