### PR TITLE
Showcase using OWNERS files with Own

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,1 @@
+@camdencheek

--- a/OWNERS
+++ b/OWNERS
@@ -1,1 +1,1 @@
-@camdencheek
+@cbart

--- a/internal/OWNERS
+++ b/internal/OWNERS
@@ -1,0 +1,1 @@
+@internal-team

--- a/internal/multierror/OWNERS
+++ b/internal/multierror/OWNERS
@@ -1,0 +1,2 @@
+errors@sourcegraph.com
+@multierrors-team

--- a/panics/OWNERS
+++ b/panics/OWNERS
@@ -1,0 +1,1 @@
+panics@sourcegraph.com

--- a/stream/OWNERS
+++ b/stream/OWNERS
@@ -1,0 +1,1 @@
+streamers@sourcegraph.com

--- a/tools/update_owners.go
+++ b/tools/update_owners.go
@@ -41,7 +41,12 @@ func main() {
 			}
 
 			allOwners := append(parentOwners, owners...)
-			fmt.Printf("/%s/**/* %s\n", relPath, strings.Join(allOwners, " "))
+			if relPath == "." {
+				relPath = ""
+			} else {
+				relPath = fmt.Sprintf("/%s", relPath)
+			}
+			fmt.Printf("%s/**/* %s\n", relPath, strings.Join(allOwners, " "))
 		}
 
 		return nil

--- a/tools/update_owners.go
+++ b/tools/update_owners.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = filepath.Walk(cwd, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		if filepath.Base(path) == "OWNERS" {
+			relPath, err := filepath.Rel(cwd, filepath.Dir(path))
+			if err != nil {
+				return err
+			}
+
+			parentOwners, err := collectParentOwners(cwd, relPath)
+			if err != nil {
+				return err
+			}
+
+			owners, err := parseOwnersFile(path)
+			if err != nil {
+				return err
+			}
+
+			allOwners := append(parentOwners, owners...)
+			fmt.Printf("/%s/**/* %s\n", relPath, strings.Join(allOwners, " "))
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func parseOwnersFile(path string) ([]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	owners := []string{}
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		owner := scanner.Text()
+		if owner != "" {
+			owners = append(owners, owner)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return owners, nil
+}
+
+func collectParentOwners(cwd, relPath string) ([]string, error) {
+	parents := strings.Split(relPath, string(filepath.Separator))
+	parentOwners := []string{}
+
+	for i := range parents {
+		parentPath := filepath.Join(cwd, filepath.Join(parents[:i]...))
+		ownersFile := filepath.Join(parentPath, "OWNERS")
+
+		if _, err := os.Stat(ownersFile); !os.IsNotExist(err) {
+			owners, err := parseOwnersFile(ownersFile)
+			if err != nil {
+				return nil, err
+			}
+			parentOwners = append(parentOwners, owners...)
+		}
+	}
+
+	return parentOwners, nil
+}


### PR DESCRIPTION
Sorry, this is not an actual pull request to conc, but an own experiment :yikes:

To use it, after authenticating with a sourcegraph instance where conc is ingested:

```
cd conc
go run tools/update_owners.go | src codeowners update -repo='github.com/sourcegraph/conc' -f -
```

OWNERS files suddenly serve code ownership searches in conc despite a different format.

See here: https://www.loom.com/share/72fd7f62632c4bc7a44cf31ede18197c

Note:
this is a very rudimentary and primitive implementation of the [OWNERS format](https://chromium.googlesource.com/chromium/src/+/master/docs/code_reviews.md#owners-files), but this took 15 minutes to implement (using cody ofc), and the principles are the same as with any other format we may want.