### PR TITLE
Remove outdated TODO

### DIFF
--- a/iter/map.go
+++ b/iter/map.go
@@ -56,7 +56,6 @@ func (m Mapper[T, R]) MapErr(input []T, f func(*T) (R, error)) ([]R, error) {
 		res[i], err = f(t)
 		if err != nil {
 			errMux.Lock()
-			// TODO: use stdlib errors once multierrors land in go 1.20
 			errs = multierror.Join(errs, err)
 			errMux.Unlock()
 		}


### PR DESCRIPTION
We use the new error facilities when built with go 1.20, so this TODO no longer applies.