### PR TITLE
Add `WithFailFast()`

### DIFF
--- a/pool/context_pool.go
+++ b/pool/context_pool.go
@@ -81,6 +81,16 @@ func (p *ContextPool) WithCancelOnError() *ContextPool {
 	return p
 }
 
+// WithFailFast is an alias for the combination of WithFirstError and
+// WithCancelOnError. By default, the errors from all tasks are returned and
+// the pool's context is not canceled until the parent context is canceled.
+func (p *ContextPool) WithFailFast() *ContextPool {
+	p.panicIfInitialized()
+	p.WithFirstError()
+	p.WithCancelOnError()
+	return p
+}
+
 // WithMaxGoroutines limits the number of goroutines in a pool.
 // Defaults to unlimited. Panics if n < 1.
 func (p *ContextPool) WithMaxGoroutines(n int) *ContextPool {

--- a/pool/context_pool_test.go
+++ b/pool/context_pool_test.go
@@ -187,9 +187,9 @@ func TestContextPool(t *testing.T) {
 		require.NotErrorIs(t, err, err2)
 	})
 
-	t.Run("WithFirstError and WithCancelOnError", func(t *testing.T) {
+	t.Run("WithFailFast", func(t *testing.T) {
 		t.Parallel()
-		p := New().WithContext(bgctx).WithFirstError().WithCancelOnError()
+		p := New().WithContext(bgctx).WithFailFast()
 		p.Go(func(ctx context.Context) error {
 			return err1
 		})

--- a/pool/result_context_pool.go
+++ b/pool/result_context_pool.go
@@ -62,6 +62,15 @@ func (p *ResultContextPool[T]) WithCancelOnError() *ResultContextPool[T] {
 	return p
 }
 
+// WithFailFast is an alias for the combination of WithFirstError and
+// WithCancelOnError. By default, the errors from all tasks are returned and
+// the pool's context is not canceled until the parent context is canceled.
+func (p *ResultContextPool[T]) WithFailFast() *ResultContextPool[T] {
+	p.panicIfInitialized()
+	p.contextPool.WithFailFast()
+	return p
+}
+
 // WithMaxGoroutines limits the number of goroutines in a pool.
 // Defaults to unlimited. Panics if n < 1.
 func (p *ResultContextPool[T]) WithMaxGoroutines(n int) *ResultContextPool[T] {


### PR DESCRIPTION
In https://github.com/sourcegraph/conc/pull/104, a "FailFast" option is likely going to be added to iterators that, on error, stops running additional tasks and returns the error that caused the first failure. 

"FailFast" seems is a pretty standard description for this behavior, and combining two common options into a single option with a more discoverable name seems like a nice thing to do before 1.0.