### PR TITLE
feat: Try executes f when f isn't nil

### DIFF
--- a/panics/panics.go
+++ b/panics/panics.go
@@ -20,7 +20,9 @@ type Catcher struct {
 // to call from multiple goroutines simultaneously.
 func (p *Catcher) Try(f func()) {
 	defer p.tryRecover()
-	f()
+	if f != nil {
+		f()
+	}
 }
 
 func (p *Catcher) tryRecover() {


### PR DESCRIPTION
Let's take a glance at the example in the official document

```go
func main() {
	times := []int{20, 52, 16, 45, 4, 80}

	streams := stream.New()
	for i, millis := range times {
		dur := time.Duration(millis) * time.Millisecond
		i := i
		streams.Go(func() stream.Callback {
			if i == 0 {
				// return nil
				return func() {}
			}
			time.Sleep(dur)
			// This will print in the order the tasks were submitted
			return func() { fmt.Println(dur) }
		})
	}
	streams.Wait()
}
``` 

In the code above, when `i == 0` (generally stands for some kind of error, ), I have to return `func() {}`, if nil is returned, a panic will be spawned because of Stream's callbacker method which repanics

```go
func (s *Stream) callbacker() {
	var panicCatcher panics. Catcher
	defer panicCatcher.Repanic()
        ...
}
``` 

Because nil is a valid value for closure, It's kind of obscure for users, who might  be thinking Oh no my code is elegant and perfect why a panic is thrown out still and take some time into troubleshooting the issue. 

So that's the reason why I proposed this PR. Hopefully `f` will be checked before it's executed. Have a nice day. 