### PR TITLE
Create a new method GoWithClosure

### DIFF
--- a/panics/panics.go
+++ b/panics/panics.go
@@ -23,6 +23,12 @@ func (p *Catcher) Try(f func()) {
 	f()
 }
 
+// TryWithClosure executes f with closure
+func (p *Catcher) TryWithClosure(f func(v any), v any) {
+	defer p.tryRecover()
+	f(v)
+}
+
 func (p *Catcher) tryRecover() {
 	if val := recover(); val != nil {
 		rp := NewRecovered(1, val)

--- a/waitgroup.go
+++ b/waitgroup.go
@@ -33,6 +33,15 @@ func (h *WaitGroup) Go(f func()) {
 	}()
 }
 
+// GoWithClosure spawns a new goroutine with closure in the WaitGroup.
+func (h *WaitGroup) GoWithClosure(f func(v any), v any) {
+	h.wg.Add(1)
+	go func(v any) {
+		defer h.wg.Done()
+		h.pc.TryWithClosure(f, v)
+	}(v)
+}
+
 // Wait will block until all goroutines spawned with Go exit and will
 // propagate any panics spawned in a child goroutine.
 func (h *WaitGroup) Wait() {

--- a/waitgroup_test.go
+++ b/waitgroup_test.go
@@ -2,6 +2,7 @@ package conc
 
 import (
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -22,6 +23,30 @@ func ExampleWaitGroup() {
 	fmt.Println(count.Load())
 	// Output:
 	// 10
+}
+func ExampleWaitGroup_GoWithClosure() {
+	var count atomic.Int64
+	set := make(map[int]struct{})
+	var lock sync.Mutex
+	put := func(i int) {
+		lock.Lock()
+		set[i] = struct{}{}
+		lock.Unlock()
+
+	}
+
+	var wg WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.GoWithClosure(func(v any) {
+			count.Add(1)
+			put(v.(int))
+		}, i)
+	}
+	wg.Wait()
+
+	fmt.Println(count.Load(), len(set))
+	// Output:
+	// 10 10
 }
 
 func ExampleWaitGroup_WaitAndRecover() {


### PR DESCRIPTION
Executing the following code will get the same output: `goroutine 10`
```go
	var wg WaitGroup
	for i := 0; i < 10; i++ {
		//i := i
		wg.Go(func() {
			log.Printf("goroutine %d", i)
		})
	}
	wg.Wait()
```

So create a new method, We can enter the closure param:
```go
	var wg WaitGroup
	for i := 0; i < 10; i++ {
		wg.GoWithClosure(func(i any) {
			log.Printf("goroutine %d", i)
			count.Add(1)
		}, i)
	}
	wg.Wait()
```