### PR TITLE
Use *_test packages to make examples copy-pasteable

### DIFF
--- a/iter/export_test.go
+++ b/iter/export_test.go
@@ -1,0 +1,3 @@
+package iter
+
+var DefaultMaxGoroutines = defaultMaxGoroutines

--- a/iter/map_test.go
+++ b/iter/map_test.go
@@ -1,16 +1,18 @@
-package iter
+package iter_test
 
 import (
 	"errors"
 	"fmt"
 	"testing"
 
+	"github.com/sourcegraph/conc/iter"
+
 	"github.com/stretchr/testify/require"
 )
 
 func ExampleMapper() {
 	input := []int{1, 2, 3, 4}
-	mapper := Mapper[int, bool]{
+	mapper := iter.Mapper[int, bool]{
 		MaxGoroutines: len(input) / 2,
 	}
 
@@ -27,7 +29,7 @@ func TestMap(t *testing.T) {
 		t.Parallel()
 		f := func() {
 			ints := []int{}
-			Map(ints, func(val *int) int {
+			iter.Map(ints, func(val *int) int {
 				panic("this should never be called")
 			})
 		}
@@ -38,7 +40,7 @@ func TestMap(t *testing.T) {
 		t.Parallel()
 		f := func() {
 			ints := []int{1}
-			Map(ints, func(val *int) int {
+			iter.Map(ints, func(val *int) int {
 				panic("super bad thing happened")
 			})
 		}
@@ -48,7 +50,7 @@ func TestMap(t *testing.T) {
 	t.Run("mutating inputs is fine, though not recommended", func(t *testing.T) {
 		t.Parallel()
 		ints := []int{1, 2, 3, 4, 5}
-		Map(ints, func(val *int) int {
+		iter.Map(ints, func(val *int) int {
 			*val += 1
 			return 0
 		})
@@ -58,7 +60,7 @@ func TestMap(t *testing.T) {
 	t.Run("basic increment", func(t *testing.T) {
 		t.Parallel()
 		ints := []int{1, 2, 3, 4, 5}
-		res := Map(ints, func(val *int) int {
+		res := iter.Map(ints, func(val *int) int {
 			return *val + 1
 		})
 		require.Equal(t, []int{2, 3, 4, 5, 6}, res)
@@ -68,7 +70,7 @@ func TestMap(t *testing.T) {
 	t.Run("huge inputs", func(t *testing.T) {
 		t.Parallel()
 		ints := make([]int, 10000)
-		res := Map(ints, func(val *int) int {
+		res := iter.Map(ints, func(val *int) int {
 			return 1
 		})
 		expected := make([]int, 10000)
@@ -86,7 +88,7 @@ func TestMapErr(t *testing.T) {
 		t.Parallel()
 		f := func() {
 			ints := []int{}
-			res, err := MapErr(ints, func(val *int) (int, error) {
+			res, err := iter.MapErr(ints, func(val *int) (int, error) {
 				panic("this should never be called")
 			})
 			require.NoError(t, err)
@@ -99,7 +101,7 @@ func TestMapErr(t *testing.T) {
 		t.Parallel()
 		f := func() {
 			ints := []int{1}
-			_, _ = MapErr(ints, func(val *int) (int, error) {
+			_, _ = iter.MapErr(ints, func(val *int) (int, error) {
 				panic("super bad thing happened")
 			})
 		}
@@ -109,7 +111,7 @@ func TestMapErr(t *testing.T) {
 	t.Run("mutating inputs is fine, though not recommended", func(t *testing.T) {
 		t.Parallel()
 		ints := []int{1, 2, 3, 4, 5}
-		res, err := MapErr(ints, func(val *int) (int, error) {
+		res, err := iter.MapErr(ints, func(val *int) (int, error) {
 			*val += 1
 			return 0, nil
 		})
@@ -121,7 +123,7 @@ func TestMapErr(t *testing.T) {
 	t.Run("basic increment", func(t *testing.T) {
 		t.Parallel()
 		ints := []int{1, 2, 3, 4, 5}
-		res, err := MapErr(ints, func(val *int) (int, error) {
+		res, err := iter.MapErr(ints, func(val *int) (int, error) {
 			return *val + 1, nil
 		})
 		require.NoError(t, err)
@@ -135,7 +137,7 @@ func TestMapErr(t *testing.T) {
 	t.Run("error is propagated", func(t *testing.T) {
 		t.Parallel()
 		ints := []int{1, 2, 3, 4, 5}
-		res, err := MapErr(ints, func(val *int) (int, error) {
+		res, err := iter.MapErr(ints, func(val *int) (int, error) {
 			if *val == 3 {
 				return 0, err1
 			}
@@ -149,7 +151,7 @@ func TestMapErr(t *testing.T) {
 	t.Run("multiple errors are propagated", func(t *testing.T) {
 		t.Parallel()
 		ints := []int{1, 2, 3, 4, 5}
-		res, err := MapErr(ints, func(val *int) (int, error) {
+		res, err := iter.MapErr(ints, func(val *int) (int, error) {
 			if *val == 3 {
 				return 0, err1
 			}
@@ -167,7 +169,7 @@ func TestMapErr(t *testing.T) {
 	t.Run("huge inputs", func(t *testing.T) {
 		t.Parallel()
 		ints := make([]int, 10000)
-		res := Map(ints, func(val *int) int {
+		res := iter.Map(ints, func(val *int) int {
 			return 1
 		})
 		expected := make([]int, 10000)

--- a/panics/try_test.go
+++ b/panics/try_test.go
@@ -1,8 +1,10 @@
-package panics
+package panics_test
 
 import (
 	"errors"
 	"testing"
+
+	"github.com/sourcegraph/conc/panics"
 
 	"github.com/stretchr/testify/require"
 )
@@ -14,7 +16,7 @@ func TestTry(t *testing.T) {
 		t.Parallel()
 
 		err := errors.New("SOS")
-		recovered := Try(func() { panic(err) })
+		recovered := panics.Try(func() { panic(err) })
 		require.ErrorIs(t, recovered.AsError(), err)
 		require.ErrorAs(t, recovered.AsError(), &err)
 		// The exact contents aren't tested because the stacktrace contains local file paths
@@ -27,7 +29,7 @@ func TestTry(t *testing.T) {
 	t.Run("no panic", func(t *testing.T) {
 		t.Parallel()
 
-		recovered := Try(func() {})
+		recovered := panics.Try(func() {})
 		require.Nil(t, recovered)
 	})
 }

--- a/pool/error_pool_test.go
+++ b/pool/error_pool_test.go
@@ -1,4 +1,4 @@
-package pool
+package pool_test
 
 import (
 	"errors"
@@ -8,11 +8,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sourcegraph/conc/pool"
+
 	"github.com/stretchr/testify/require"
 )
 
 func ExampleErrorPool() {
-	p := New().WithErrors()
+	p := pool.New().WithErrors()
 	for i := 0; i < 3; i++ {
 		i := i
 		p.Go(func() error {
@@ -37,14 +39,14 @@ func TestErrorPool(t *testing.T) {
 	t.Run("panics on configuration after init", func(t *testing.T) {
 		t.Run("before wait", func(t *testing.T) {
 			t.Parallel()
-			g := New().WithErrors()
+			g := pool.New().WithErrors()
 			g.Go(func() error { return nil })
 			require.Panics(t, func() { g.WithMaxGoroutines(10) })
 		})
 
 		t.Run("after wait", func(t *testing.T) {
 			t.Parallel()
-			g := New().WithErrors()
+			g := pool.New().WithErrors()
 			g.Go(func() error { return nil })
 			_ = g.Wait()
 			require.Panics(t, func() { g.WithMaxGoroutines(10) })
@@ -53,21 +55,21 @@ func TestErrorPool(t *testing.T) {
 
 	t.Run("wait returns no error if no errors", func(t *testing.T) {
 		t.Parallel()
-		g := New().WithErrors()
+		g := pool.New().WithErrors()
 		g.Go(func() error { return nil })
 		require.NoError(t, g.Wait())
 	})
 
 	t.Run("wait error if func returns error", func(t *testing.T) {
 		t.Parallel()
-		g := New().WithErrors()
+		g := pool.New().WithErrors()
 		g.Go(func() error { return err1 })
 		require.ErrorIs(t, g.Wait(), err1)
 	})
 
 	t.Run("wait error is all returned errors", func(t *testing.T) {
 		t.Parallel()
-		g := New().WithErrors()
+		g := pool.New().WithErrors()
 		g.Go(func() error { return err1 })
 		g.Go(func() error { return nil })
 		g.Go(func() error { return err2 })
@@ -78,7 +80,7 @@ func TestErrorPool(t *testing.T) {
 
 	t.Run("propagates panics", func(t *testing.T) {
 		t.Parallel()
-		g := New().WithErrors()
+		g := pool.New().WithErrors()
 		for i := 0; i < 10; i++ {
 			i := i
 			g.Go(func() error {
@@ -95,7 +97,7 @@ func TestErrorPool(t *testing.T) {
 		t.Parallel()
 		for _, maxGoroutines := range []int{1, 10, 100} {
 			t.Run(strconv.Itoa(maxGoroutines), func(t *testing.T) {
-				g := New().WithErrors().WithMaxGoroutines(maxGoroutines)
+				g := pool.New().WithErrors().WithMaxGoroutines(maxGoroutines)
 
 				var currentConcurrent atomic.Int64
 				taskCount := maxGoroutines * 10

--- a/pool/result_pool_test.go
+++ b/pool/result_pool_test.go
@@ -1,4 +1,4 @@
-package pool
+package pool_test
 
 import (
 	"fmt"
@@ -8,11 +8,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sourcegraph/conc/pool"
+
 	"github.com/stretchr/testify/require"
 )
 
 func ExampleResultPool() {
-	p := NewWithResults[int]()
+	p := pool.NewWithResults[int]()
 	for i := 0; i < 10; i++ {
 		i := i
 		p.Go(func() int {
@@ -34,14 +36,14 @@ func TestResultGroup(t *testing.T) {
 	t.Run("panics on configuration after init", func(t *testing.T) {
 		t.Run("before wait", func(t *testing.T) {
 			t.Parallel()
-			g := NewWithResults[int]()
+			g := pool.NewWithResults[int]()
 			g.Go(func() int { return 0 })
 			require.Panics(t, func() { g.WithMaxGoroutines(10) })
 		})
 
 		t.Run("after wait", func(t *testing.T) {
 			t.Parallel()
-			g := NewWithResults[int]()
+			g := pool.NewWithResults[int]()
 			g.Go(func() int { return 0 })
 			_ = g.Wait()
 			require.Panics(t, func() { g.WithMaxGoroutines(10) })
@@ -50,7 +52,7 @@ func TestResultGroup(t *testing.T) {
 
 	t.Run("basic", func(t *testing.T) {
 		t.Parallel()
-		g := NewWithResults[int]()
+		g := pool.NewWithResults[int]()
 		expected := []int{}
 		for i := 0; i < 100; i++ {
 			i := i
@@ -68,7 +70,7 @@ func TestResultGroup(t *testing.T) {
 		t.Parallel()
 		for _, maxGoroutines := range []int{1, 10, 100} {
 			t.Run(strconv.Itoa(maxGoroutines), func(t *testing.T) {
-				g := NewWithResults[int]().WithMaxGoroutines(maxGoroutines)
+				g := pool.NewWithResults[int]().WithMaxGoroutines(maxGoroutines)
 
 				var currentConcurrent atomic.Int64
 				var errCount atomic.Int64

--- a/waitgroup_test.go
+++ b/waitgroup_test.go
@@ -1,9 +1,11 @@
-package conc
+package conc_test
 
 import (
 	"fmt"
 	"sync/atomic"
 	"testing"
+
+	"github.com/sourcegraph/conc"
 
 	"github.com/stretchr/testify/require"
 )
@@ -11,7 +13,7 @@ import (
 func ExampleWaitGroup() {
 	var count atomic.Int64
 
-	var wg WaitGroup
+	var wg conc.WaitGroup
 	for i := 0; i < 10; i++ {
 		wg.Go(func() {
 			count.Add(1)
@@ -25,7 +27,7 @@ func ExampleWaitGroup() {
 }
 
 func ExampleWaitGroup_WaitAndRecover() {
-	var wg WaitGroup
+	var wg conc.WaitGroup
 
 	wg.Go(func() {
 		panic("super bad thing")
@@ -42,14 +44,14 @@ func TestWaitGroup(t *testing.T) {
 
 	t.Run("ctor", func(t *testing.T) {
 		t.Parallel()
-		wg := NewWaitGroup()
-		require.IsType(t, &WaitGroup{}, wg)
+		wg := conc.NewWaitGroup()
+		require.IsType(t, &conc.WaitGroup{}, wg)
 	})
 
 	t.Run("all spawned run", func(t *testing.T) {
 		t.Parallel()
 		var count atomic.Int64
-		var wg WaitGroup
+		var wg conc.WaitGroup
 		for i := 0; i < 100; i++ {
 			wg.Go(func() {
 				count.Add(1)
@@ -64,7 +66,7 @@ func TestWaitGroup(t *testing.T) {
 
 		t.Run("is propagated", func(t *testing.T) {
 			t.Parallel()
-			var wg WaitGroup
+			var wg conc.WaitGroup
 			wg.Go(func() {
 				panic("super bad thing")
 			})
@@ -73,7 +75,7 @@ func TestWaitGroup(t *testing.T) {
 
 		t.Run("one is propagated", func(t *testing.T) {
 			t.Parallel()
-			var wg WaitGroup
+			var wg conc.WaitGroup
 			wg.Go(func() {
 				panic("super bad thing")
 			})
@@ -85,7 +87,7 @@ func TestWaitGroup(t *testing.T) {
 
 		t.Run("non-panics do not overwrite panic", func(t *testing.T) {
 			t.Parallel()
-			var wg WaitGroup
+			var wg conc.WaitGroup
 			wg.Go(func() {
 				panic("super bad thing")
 			})
@@ -97,7 +99,7 @@ func TestWaitGroup(t *testing.T) {
 
 		t.Run("non-panics run successfully", func(t *testing.T) {
 			t.Parallel()
-			var wg WaitGroup
+			var wg conc.WaitGroup
 			var i atomic.Int64
 			wg.Go(func() {
 				i.Add(1)
@@ -114,7 +116,7 @@ func TestWaitGroup(t *testing.T) {
 
 		t.Run("is caught by waitandrecover", func(t *testing.T) {
 			t.Parallel()
-			var wg WaitGroup
+			var wg conc.WaitGroup
 			wg.Go(func() {
 				panic("super bad thing")
 			})
@@ -124,7 +126,7 @@ func TestWaitGroup(t *testing.T) {
 
 		t.Run("one is caught by waitandrecover", func(t *testing.T) {
 			t.Parallel()
-			var wg WaitGroup
+			var wg conc.WaitGroup
 			wg.Go(func() {
 				panic("super bad thing")
 			})
@@ -137,7 +139,7 @@ func TestWaitGroup(t *testing.T) {
 
 		t.Run("nonpanics run successfully with waitandrecover", func(t *testing.T) {
 			t.Parallel()
-			var wg WaitGroup
+			var wg conc.WaitGroup
 			var i atomic.Int64
 			wg.Go(func() {
 				i.Add(1)


### PR DESCRIPTION
The main reason for this PR was to make the examples in documentation
copy-pasteable, but there are some additional benefits too.

For example, the pool example before this change:

```go
p := New().WithMaxGoroutines(3)
for i := 0; i < 5; i++ {
	p.Go(func() {
		fmt.Println("conc")
	})
}
p.Wait()
```

and after:

```go
p := pool.New().WithMaxGoroutines(3) // has package name
for i := 0; i < 5; i++ {
	p.Go(func() {
		fmt.Println("conc")
	})
}
p.Wait()
```

The function `defaultMaxGoroutines` in `iter` package had to be exported because it was used from the tests. 
