### PR TITLE
Make result order deterministic

### DIFF
--- a/pool/result_context_pool.go
+++ b/pool/result_context_pool.go
@@ -14,7 +14,7 @@ import (
 type ResultContextPool[T any] struct {
 	contextPool    ContextPool
 	agg            resultAggregator[T]
-	includeErrored bool
+	collectErrored bool
 }
 
 // Go submits a task to the pool. If all goroutines in the pool
@@ -32,7 +32,7 @@ func (p *ResultContextPool[T]) Go(f func(context.Context) (T, error)) {
 // returns an error if any of the tasks errored.
 func (p *ResultContextPool[T]) Wait() ([]T, error) {
 	err := p.contextPool.Wait()
-	return p.agg.collect(p.includeErrored), err
+	return p.agg.collect(p.collectErrored), err
 }
 
 // WithCollectErrored configures the pool to still collect the result of a task
@@ -40,7 +40,7 @@ func (p *ResultContextPool[T]) Wait() ([]T, error) {
 // are ignored and only the error is collected.
 func (p *ResultContextPool[T]) WithCollectErrored() *ResultContextPool[T] {
 	p.panicIfInitialized()
-	p.includeErrored = true
+	p.collectErrored = true
 	return p
 }
 

--- a/pool/result_context_pool_test.go
+++ b/pool/result_context_pool_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -223,7 +222,6 @@ func TestResultContextPool(t *testing.T) {
 					})
 				}
 				res, err := g.Wait()
-				sort.Ints(res)
 				require.Equal(t, expected, res)
 				require.NoError(t, err)
 				require.Equal(t, int64(0), currentConcurrent.Load())

--- a/pool/result_error_pool.go
+++ b/pool/result_error_pool.go
@@ -16,7 +16,7 @@ import (
 type ResultErrorPool[T any] struct {
 	errorPool      ErrorPool
 	agg            resultAggregator[T]
-	includeErrored bool
+	collectErrored bool
 }
 
 // Go submits a task to the pool. If all goroutines in the pool
@@ -34,7 +34,7 @@ func (p *ResultErrorPool[T]) Go(f func() (T, error)) {
 // returning the results and any errors from tasks.
 func (p *ResultErrorPool[T]) Wait() ([]T, error) {
 	err := p.errorPool.Wait()
-	return p.agg.collect(p.includeErrored), err
+	return p.agg.collect(p.collectErrored), err
 }
 
 // WithCollectErrored configures the pool to still collect the result of a task
@@ -42,7 +42,7 @@ func (p *ResultErrorPool[T]) Wait() ([]T, error) {
 // are ignored and only the error is collected.
 func (p *ResultErrorPool[T]) WithCollectErrored() *ResultErrorPool[T] {
 	p.panicIfInitialized()
-	p.includeErrored = true
+	p.collectErrored = true
 	return p
 }
 

--- a/pool/result_error_pool.go
+++ b/pool/result_error_pool.go
@@ -8,9 +8,8 @@ import (
 // type and an error. Tasks are executed in the pool with Go(), then the
 // results of the tasks are returned by Wait().
 //
-// The order of the results is not guaranteed to be the same as the order the
-// tasks were submitted. If your use case requires consistent ordering,
-// consider using the `stream` package or `Map` from the `iter` package.
+// The order of the results is guaranteed to be the same as the order the
+// tasks were submitted.
 //
 // The configuration methods (With*) will panic if they are used after calling
 // Go() for the first time.

--- a/pool/result_error_pool_test.go
+++ b/pool/result_error_pool_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestResultErrorGroup(t *testing.T) {
+func TestResultErrorPool(t *testing.T) {
 	t.Parallel()
 
 	err1 := errors.New("err1")

--- a/pool/result_pool.go
+++ b/pool/result_pool.go
@@ -20,9 +20,8 @@ func NewWithResults[T any]() *ResultPool[T] {
 // Tasks are executed in the pool with Go(), then the results of the tasks are
 // returned by Wait().
 //
-// The order of the results is not guaranteed to be the same as the order the
-// tasks were submitted. If your use case requires consistent ordering,
-// consider using the `stream` package or `Map` from the `iter` package.
+// The order of the results is guaranteed to be the same as the order the
+// tasks were submitted.
 type ResultPool[T any] struct {
 	pool Pool
 	agg  resultAggregator[T]

--- a/pool/result_pool.go
+++ b/pool/result_pool.go
@@ -117,7 +117,7 @@ func (r *resultAggregator[T]) save(i int, res T, errored bool) {
 	}
 }
 
-// collect returns the set of aggregated results
+// collect returns the set of aggregated results.
 func (r *resultAggregator[T]) collect(includeErrored bool) []T {
 	if !r.mu.TryLock() {
 		panic("collect should not be called until all goroutines have exited")

--- a/pool/result_pool.go
+++ b/pool/result_pool.go
@@ -2,7 +2,7 @@ package pool
 
 import (
 	"context"
-	"slices"
+	"sort"
 	"sync"
 )
 
@@ -121,7 +121,7 @@ func (r *resultAggregator[T]) collect(includeErrored bool) []T {
 	}
 
 	filtered := r.results[:0]
-	slices.Sort(r.errored)
+	sort.Ints(r.errored)
 	for i, e := range r.errored {
 		if i == 0 {
 			filtered = append(filtered, r.results[:e]...)

--- a/pool/result_pool.go
+++ b/pool/result_pool.go
@@ -118,12 +118,12 @@ func (r *resultAggregator[T]) save(i int, res T, errored bool) {
 }
 
 // collect returns the set of aggregated results.
-func (r *resultAggregator[T]) collect(includeErrored bool) []T {
+func (r *resultAggregator[T]) collect(collectErrored bool) []T {
 	if !r.mu.TryLock() {
 		panic("collect should not be called until all goroutines have exited")
 	}
 
-	if includeErrored || len(r.errored) == 0 {
+	if collectErrored || len(r.errored) == 0 {
 		return r.results
 	}
 

--- a/pool/result_pool_test.go
+++ b/pool/result_pool_test.go
@@ -81,7 +81,6 @@ func TestResultGroup(t *testing.T) {
 		}
 		got := p.Wait()
 		require.Equal(t, results, got)
-
 	})
 
 	t.Run("limit", func(t *testing.T) {

--- a/pool/result_pool_test.go
+++ b/pool/result_pool_test.go
@@ -3,7 +3,6 @@ package pool_test
 import (
 	"fmt"
 	"math/rand"
-	"sort"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -61,7 +60,6 @@ func TestResultGroup(t *testing.T) {
 			})
 		}
 		res := g.Wait()
-		sort.Ints(res)
 		require.Equal(t, expected, res)
 	})
 
@@ -75,6 +73,8 @@ func TestResultGroup(t *testing.T) {
 		for _, result := range results {
 			result := result
 			p.Go(func() int {
+				// Add a random sleep to make it exceedingly unlikely that the
+				// results are returned in the order they are submitted.
 				time.Sleep(time.Duration(rand.Int()%100) * time.Millisecond)
 				return result
 			})
@@ -108,7 +108,6 @@ func TestResultGroup(t *testing.T) {
 					})
 				}
 				res := g.Wait()
-				sort.Ints(res)
 				require.Equal(t, expected, res)
 				require.Equal(t, int64(0), errCount.Load())
 				require.Equal(t, int64(0), currentConcurrent.Load())


### PR DESCRIPTION
This PR makes the order of results in a `Result.*Pool` deterministic so that the order of the result slice corresponds with the order of tasks submitted. As an example of why this would be useful, it makes it easy to rewrite `iter.Map` in terms of `ResultPool`. Additionally, it's a generally nice and intuitive property to be able to match the index of the result slice with the index of the input slice. 

Comments inline.