### PR TITLE
Exclusively use go1.20 multierrors

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: ['1.19', 'stable']
+        go-version: ['1.20', 'stable']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -455,17 +455,6 @@ func mapStream(
 </tr>
 </table>
 
-# Errors
-
-In general, `conc` handles multiple errors from tasks by joining them into
-a single "multierror". In go 1.19, we use Uber's multierror package, but
-in version 1.20, go added native support for joining errors so we use that
-instead. Note that, if you are relying on converting an error back into its
-component errors, the behavior changes between go 1.19 and go 1.20 and
-you should use the `Unwrap() []error` method instead of casting the error
-as a `*multierror.Error`. `errors.As` and `errors.Is` should continue
-to work as expected.
-
 # Status
 
 This package is currently pre-1.0. There are likely to be minor breaking

--- a/go.mod
+++ b/go.mod
@@ -1,18 +1,14 @@
 module github.com/sourcegraph/conc
 
-go 1.19
+go 1.20
 
-require (
-	github.com/stretchr/testify v1.8.1
-	go.uber.org/multierr v1.9.0
-)
+require github.com/stretchr/testify v1.8.1
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
-	go.uber.org/atomic v1.7.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -17,15 +17,10 @@ github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/f
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
-go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-go.uber.org/multierr v1.9.0 h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=
-go.uber.org/multierr v1.9.0/go.mod h1:X2jQV1h+kxSjClGpnseKVIxpmcjrj7MNnI0bnlfKTVQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=

--- a/internal/multierror/multierror_go119.go
+++ b/internal/multierror/multierror_go119.go
@@ -1,9 +1,0 @@
-//go:build !go1.20
-
-package multierror
-
-import "go.uber.org/multierr"
-
-var (
-	Join = multierr.Combine
-)

--- a/internal/multierror/multierror_go120.go
+++ b/internal/multierror/multierror_go120.go
@@ -1,9 +1,0 @@
-//go:build go1.20
-
-package multierror
-
-import "errors"
-
-var (
-	Join = errors.Join
-)

--- a/iter/map.go
+++ b/iter/map.go
@@ -1,9 +1,8 @@
 package iter
 
 import (
+	"errors"
 	"sync"
-
-	"github.com/sourcegraph/conc/internal/multierror"
 )
 
 // Mapper is an Iterator with a result type R. It can be used to configure
@@ -60,5 +59,5 @@ func (m Mapper[T, R]) MapErr(input []T, f func(*T) (R, error)) ([]R, error) {
 			errMux.Unlock()
 		}
 	})
-	return res, multierror.Join(errs...)
+	return res, errors.Join(errs...)
 }

--- a/iter/map_test.go
+++ b/iter/map_test.go
@@ -162,6 +162,7 @@ func TestMapErr(t *testing.T) {
 		})
 		require.ErrorIs(t, err, err1)
 		require.ErrorIs(t, err, err2)
+		require.ElementsMatch(t, err.(interface{ Unwrap() []error }).Unwrap(), []error{err1, err2})
 		require.Equal(t, []int{2, 3, 0, 0, 6}, res)
 		require.Equal(t, []int{1, 2, 3, 4, 5}, ints)
 	})

--- a/pool/error_pool.go
+++ b/pool/error_pool.go
@@ -43,7 +43,7 @@ func (p *ErrorPool) Wait() error {
 	} else if p.onlyFirstError {
 		return errs[0]
 	} else {
-		return errors.Join(p.errs...)
+		return errors.Join(errs...)
 	}
 }
 

--- a/pool/error_pool.go
+++ b/pool/error_pool.go
@@ -2,9 +2,8 @@ package pool
 
 import (
 	"context"
+	"errors"
 	"sync"
-
-	"github.com/sourcegraph/conc/internal/multierror"
 )
 
 // ErrorPool is a pool that runs tasks that may return an error.
@@ -44,7 +43,7 @@ func (p *ErrorPool) Wait() error {
 	} else if p.onlyFirstError {
 		return errs[0]
 	} else {
-		return multierror.Join(errs...)
+		return errors.Join(p.errs...)
 	}
 }
 


### PR DESCRIPTION
This PR removes the dependency on `go.uber.org/multierror` in favor of the multierror functionality included in go 1.20. 

As a consequence, this removes support for go versions earlier than go 1.20. In order to maintain the standard "two minor versions" support policy, this change will not be released (likely in a 1.0 version) until go 1.22 is released.