### PR TITLE
Multierror: join errors at the end

### DIFF
--- a/iter/map.go
+++ b/iter/map.go
@@ -49,16 +49,16 @@ func (m Mapper[T, R]) MapErr(input []T, f func(*T) (R, error)) ([]R, error) {
 	var (
 		res    = make([]R, len(input))
 		errMux sync.Mutex
-		errs   error
+		errs   []error
 	)
 	Iterator[T](m).ForEachIdx(input, func(i int, t *T) {
 		var err error
 		res[i], err = f(t)
 		if err != nil {
 			errMux.Lock()
-			errs = multierror.Join(errs, err)
+			errs = append(errs, err)
 			errMux.Unlock()
 		}
 	})
-	return res, errs
+	return res, multierror.Join(errs...)
 }


### PR DESCRIPTION
This fixes `MapErr` so that it does not create recursive `joinError`s. By repeatedly calling `errors.Join(`, we create a nested set of `joinError`s rather than a single, flat `joinError`. Then, when `Error()` is called, it allocates a new string for each nested error because `joinError` calls `Error()` recursively on each of its children.

Instead, this PR updates `MapErr` to just collect a slice of errors and return the flat joined error.