### PR TITLE
chore: bump go directive and fix trivy CVEs in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sourcegraph/conc
 
-go 1.20
+go 1.25.9
 
 require github.com/stretchr/testify v1.8.1
 


### PR DESCRIPTION
This PR was generated by Sourcegraph Batch Changes.

## Changes

- Bumps the `go` directive:
  - To `go 1.25.9` for modules currently below 1.26
  - To `go 1.26.2` for modules already on 1.26.x
- Removes any `toolchain` directive (toolchain selection is handled automatically)
- Runs `go mod tidy` to keep `go.sum` consistent with the new directive
- Fixes all CVEs reported by `trivy fs go.mod` by upgrading specific transitive
  dependencies to their minimum safe versions

## Why

Ensures a consistent, secure Go toolchain version across all first-party
`github.com/sourcegraph/*` modules that are depended on by `sourcegraph/sourcegraph`.

[_Hatched by a Sourcegraph egg._](https://egg.sgdev.dev/egg/publish/keegan/sourcegraph-go-version-and-trivy-fixes)